### PR TITLE
Migrate from master and slave jargon

### DIFF
--- a/RNDL/RNDLSlave.py
+++ b/RNDL/RNDLSlave.py
@@ -1,4 +1,4 @@
-# Console application for the RNDL Slave device
+# Console application for the RNDL Subordinate device
 # created by Felix Holz, 2018-07-17
 
 from transceiver import Transceiver
@@ -10,4 +10,4 @@ def callback(msg):
 
 trans = Transceiver("COM9")
 
-trans.start_slave("2", callback)
+trans.start_subordinate("2", callback)

--- a/RNDL/transceiver.py
+++ b/RNDL/transceiver.py
@@ -38,10 +38,10 @@ class Transceiver:
         ser.write("mac pause", self.s)
         ser.read(self.s)
 
-    # start slave mode with the given address and callback
+    # start subordinate mode with the given address and callback
     #   - when a message is received, it is passed on to the callback function which returns the answer
-    #   - the answer is then transmittetd back to the master
-    def start_slave(self, addr, callback):
+    #   - the answer is then transmittetd back to the main
+    def start_subordinate(self, addr, callback):
         while True:
             data = self.receive()
             print("received request: " + data)
@@ -54,9 +54,9 @@ class Transceiver:
                 if data[1] == addr:
                     self.transmit("A;" + callback(data[2]))
         
-    # request data from a slave device
-    #   addr: address of the slave
-    #   msg: message transmitted to the slave
+    # request data from a subordinate device
+    #   addr: address of the subordinate
+    #   msg: message transmitted to the subordinate
     def request_data(self, addr, msg):
         self.transmit("Q;" + str(addr) + ";" + str(msg))
 

--- a/failed attempt 1/RNDL/RNDLDevice.py
+++ b/failed attempt 1/RNDL/RNDLDevice.py
@@ -37,8 +37,8 @@ class RNDLDevice():
         reply = tr.receive(self.s)
         return reply
 
-    #starts slave mode. addr is the address of the device. request_callback should return an answer based on the request parameter
-    def start_slave(self, addr, request_callback):
+    #starts subordinate mode. addr is the address of the device. request_callback should return an answer based on the request parameter
+    def start_subordinate(self, addr, request_callback):
         while True:
             req = tr.receive(self.s)
             print(req)

--- a/failed attempt 1/RNDL/RNDLSlave.py
+++ b/failed attempt 1/RNDL/RNDLSlave.py
@@ -5,5 +5,5 @@ device = RNDLDevice("COM7")
 def cb(msg):
     return "reply"
 
-device.start_slave("12", cb)
+device.start_subordinate("12", cb)
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.